### PR TITLE
fix:(*) make old prod cache config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
 import { AppModule } from './app/';
 
+console.log('test cache');
+
 if (environment.production) {
   enableProdMode();
 }

--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -1,5 +1,6 @@
 module.exports = {
   staticFileGlobs: [
+    'dist/tools/**.html',
     'dist/tools/assets/images/chart/**.*',
     'dist/tools/assets/images/answers/**.*',
     'dist/tools/assets/images/icons/menu/**.*',


### PR DESCRIPTION
the plan is:
> We all together get ''old prod" version with cached html. Then we redeploy new version with new cache config, Oleksandra makes redirect for old js bundles and we check that all works fine.